### PR TITLE
Move instance declarations into constructor

### DIFF
--- a/src/wc-monaco-editor.js
+++ b/src/wc-monaco-editor.js
@@ -19,8 +19,11 @@ self.MonacoEnvironment = {
 }
 
 export class WCMonacoEditor extends HTMLElement {
-  __element = null;
-  __editor = null;
+  constructor () {
+    super();
+    this.__element = null;
+    this.__editor = null;
+  }
 
   static get observedAttributes() {
     return ['src', 'value'];


### PR DESCRIPTION
This allows the script to run in Safari, which does not yet support this feature.

Resolves #1